### PR TITLE
fix navigation: dont override Sales title with Refunds

### DIFF
--- a/src/Spryker/Zed/Refund/Communication/navigation.xml
+++ b/src/Spryker/Zed/Refund/Communication/navigation.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0"?>
 <config>
     <sales>
-        <label>Refunds</label>
-        <title>Refunds</title>
-        <bundle>refund</bundle>
         <pages>
             <table>
                 <label>Refunds</label>


### PR DESCRIPTION
## PR Description

The "Sales" navigation title was overridden by this module and renamed to "Refund". This PR just removes that mistake.


<img width="261" alt="Bildschirmfoto 2022-01-18 um 13 18 28" src="https://user-images.githubusercontent.com/52778227/149936223-5439e768-954f-43a1-8bd7-ec2f77b9165b.png">


## Checklist
- [ ] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
